### PR TITLE
bugfix - gifは256色使える

### DIFF
--- a/lib/swf_ruby/swf/bits_lossless2.rb
+++ b/lib/swf_ruby/swf/bits_lossless2.rb
@@ -16,7 +16,7 @@ module SwfRuby
         colormap = []
         # creating colormap to check number of colors
         image.get_pixels(0, 0, image.columns, image.rows).each_with_index do |pixel,i|
-          break if colormap.length > 255
+          break if colormap.length > 256
           idx = colormap.index(pixel)
           if idx
             data << [idx].pack("C")
@@ -31,7 +31,7 @@ module SwfRuby
         end
 
         # checking image format by size of colormap
-        if colormap.length > 255
+        if colormap.length > 256
           # format=5
           # reset and re-build data_stream without colopmap
           data = ""


### PR DESCRIPTION
tmtyskさん、はじめまして。
便利なgemをありがとうございます。利用させて頂いています。

バグっぽい箇所を発見したので、pull requestさせて頂きました。

GIFは256色使えるはずですが、
colormap.lengthのチェックが255色までになっている気がするので、
修正してみました。（間違ってたら捨てて下さい）

ご確認をお願い致します。
